### PR TITLE
meta: add `no_install` meson option

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -1,14 +1,16 @@
-project('libsmarter')
+project('libsmarter', meson_version: '>=1.1')
 
 incl = include_directories('include/')
 
-install_headers('include/smarter.hpp')
+if not get_option('no_install')
+	install_headers('include/smarter.hpp')
+
+	pkgconfig = import('pkgconfig')
+	pkgconfig.generate(
+		name: 'libsmarter',
+		description: 'A library for freestanding smart pointers in C++',
+		version: meson.project_version(),
+	)
+endif
 
 libsmarter_dep = declare_dependency(include_directories: incl)
-
-pkgconfig = import('pkgconfig')
-pkgconfig.generate(
-  name: 'libsmarter',
-  description: 'A library for freestanding smart pointers in C++',
-  version: meson.project_version(),
-)

--- a/meson.options
+++ b/meson.options
@@ -1,0 +1,1 @@
+option('no_install', type : 'boolean', value : false)


### PR DESCRIPTION
This is useful for using libsmarter as a meson subproject, as this allows for skipping the install of the headers and pkg-config files.